### PR TITLE
docs: add OrcaRouter to supported providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Older release notes are available on [GitHub Releases](https://github.com/wanxin
 - **Workflow Orchestration** 🔁: LightFlow chains agents into deterministic multi-step workflows with explicit dependencies, step output passing, retries, checkpointed run records, resume/rerun support, approval nodes, fallback agents, and traceable execution.
 - **Shared Memory Prototype** 🧠: SharedMemoryPool provides append-first in-memory shared memory with provenance metadata, scoped retrieval, and MemoryPolicy-compatible results for multi-agent experiments.
 - **Independent Execution** 🤖: Tasks and tool calls are completed autonomously without human intervention.  
-- **Multi-Model Support** 🔄: Compatible with OpenAI-style providers such as OpenAI, OpenRouter, Zhipu ChatGLM, Baichuan, StepFun, DeepSeek, Qwen, vLLM, llama.cpp, and other OpenAI-compatible endpoints.  
+- **Multi-Model Support** 🔄: Compatible with OpenAI-style providers such as OpenAI, OpenRouter, OrcaRouter, Zhipu ChatGLM, Baichuan, StepFun, DeepSeek, Qwen, vLLM, llama.cpp, and other OpenAI-compatible endpoints.  
 - **Streaming API** 🌊: Supports OpenAI streaming format API service output, seamlessly integrates with mainstream chat frameworks, enhancing user experience.  
 - **Trace Observability** 🔎: Opt-in `trace=True` run traces record structured run lifecycle, model request summaries, tool calls, tool results, and errors without changing the default string return value.  
 - **Evaluation Harness** 📊: `LightEvaluator` runs deterministic agent or LightFlow regression cases for output, tool choice, policy events, recovery, latency, usage, and estimated cost.
@@ -609,7 +609,7 @@ When upgrading from v0.9.4, audit legacy internal memory before backfilling `pro
 
 ## Mainstream Agent Model Support
 
-LightAgent works with OpenAI-compatible chat completion endpoints, including OpenAI, OpenRouter, Zhipu ChatGLM, DeepSeek, Qwen, StepFun, Moonshot/Kimi, MiniMax, vLLM, llama.cpp, Ollama-compatible endpoints, and self-hosted gateways.
+LightAgent works with OpenAI-compatible chat completion endpoints, including OpenAI, OpenRouter, OrcaRouter, Zhipu ChatGLM, DeepSeek, Qwen, StepFun, Moonshot/Kimi, MiniMax, vLLM, llama.cpp, Ollama-compatible endpoints, and self-hosted gateways.
 
 For provider-specific parameters, base URLs, local model setup, and troubleshooting, see [Model Provider Configuration](docs/model_providers.md).
 

--- a/docs/model_providers.md
+++ b/docs/model_providers.md
@@ -26,6 +26,27 @@ OpenRouter model names are provider-routed strings such as
 `openai/gpt-4.1`, `anthropic/claude-sonnet-4`, or another model listed in your
 OpenRouter account.
 
+### OrcaRouter
+
+```python
+from LightAgent import LightAgent
+
+agent = LightAgent(
+    model="openai/gpt-5.5",
+    api_key="your_orcarouter_api_key",
+    base_url="https://api.orcarouter.ai/v1",
+)
+
+print(agent.run("Who are you?"))
+```
+
+OrcaRouter is an OpenAI-compatible model routing gateway that exposes models
+from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single
+endpoint and API key. Keys start with `sk-orca-`. Model names are
+provider-routed strings such as `openai/gpt-5.5` or
+`anthropic/claude-opus-4.8`; `orcarouter/auto` is a named router that picks an
+upstream model per request.
+
 ### Atlas Cloud
 
 Atlas Cloud exposes an OpenAI-compatible `/v1` endpoint, so it works with the


### PR DESCRIPTION
## Summary

- Adds [OrcaRouter](https://www.orcarouter.ai) to the README provider lists and documents it with a dedicated section in `docs/model_providers.md`, mirroring the existing OpenRouter and Atlas Cloud sections.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Compatibility

- [x] Existing `agent.run("hello")` behavior is unchanged, or the change is documented. (docs-only change)
- [x] Existing `stream=True` behavior is unchanged, or the change is documented. (docs-only change)

## Tests

- [x] `python -m compileall -q LightAgent` (passed)
- [x] `PYTHONPATH=. python -m pytest -q tests/test_v065_core.py tests/test_v070_tracing.py tests/test_memory_policy.py` (57 passed)
- [x] Live: `LightAgent(model="openai/gpt-5.5", api_key=..., base_url="https://api.orcarouter.ai/v1")` returned `ORCA-OK`

## Notes

Documentation only. No code, API, or behavior changes.

I'm an engineer on the OrcaRouter team.
