### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ We look forward to your feedback and work together to make LightAgent even stron
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=wanxingai/LightAgent&type=Date)](https://star-history.com/#wanxingai/LightAgent&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=wanxingai/LightAgent&type=Date)](https://star-history.dera.page/#wanxingai/LightAgent&Date)
 
 ## Paper
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -442,7 +442,7 @@ LightAgent 采用 [Apache 2.0 许可证](LICENSE)。您可以自由使用、修�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=wanxingai/LightAgent&type=Date)](https://star-history.com/#wanxingai/LightAgent&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=wanxingai/LightAgent&type=Date)](https://star-history.dera.page/#wanxingai/LightAgent&Date)
 
 ## 论文
 


### PR DESCRIPTION
The star history chart in our README is currently broken because its data source relies on the GitHub stargazer API, which now enforces strict rate limits that prevent the chart from loading. This change points the chart to a working alternative service so contributors and users can see the project history again. The same fix is applied to the Chinese translation of the README.