### PR TITLE
Docs: Define third-party service contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,43 @@ PYTHONPATH=. python -m pytest -q tests/test_v065_core.py tests/test_v070_tracing
   security note in the PR.
 - Update README or `docs/` when behavior, configuration, or public APIs change.
 
+## Third-Party Services And Provider Documentation
+
+Contributions that add or replace a hosted model provider, gateway, external
+API, badge, chart, or other remote service must make the dependency and its
+trust boundary reviewable.
+
+- Disclose any employment, ownership, sponsorship, or other affiliation with
+  the service in the issue and pull request.
+- Link the service's official, publicly accessible API documentation, model or
+  feature catalog, and source repository when the service is open source.
+- Prefer provider-neutral OpenAI-compatible configuration guidance. A dedicated
+  provider section should document a meaningful compatibility detail that is
+  not already covered by `model`, `api_key`, and `base_url`.
+- Use stable example identifiers where possible. When model names or features
+  are controlled by the service, link the live catalog and state that
+  availability may change.
+- Read credentials from environment variables. Never include working keys,
+  encrypted tokens, account identifiers, or credentials embedded in public
+  URLs.
+- Include reproducible compatibility evidence for the behavior being claimed.
+  For model gateways, cover chat completions and any claimed streaming or tool
+  calling support. Clearly separate local or CI validation from credentialed
+  live-service validation.
+- Limit project documentation to verifiable configuration and compatibility
+  facts. Do not add unverified pricing, model-count, availability, performance,
+  failover, security, privacy, or regulatory guarantees.
+- For externally hosted images or embeds, identify the operator and source,
+  describe what request data leaves GitHub, and explain why a repository-owned
+  static asset is not sufficient.
+- External-contributor workflows may remain unapproved until maintainers finish
+  reviewing the proposed service dependency. CI approval does not imply project
+  endorsement of that service.
+
+Maintainers may decline or remove a dedicated listing when its claims cannot be
+independently verified, its maintenance burden is disproportionate, or generic
+OpenAI-compatible documentation already covers the integration.
+
 ## Reporting Issues
 
 Please use the bug or feature templates when possible. Security issues should be


### PR DESCRIPTION
## Summary

- define review requirements for hosted model providers, gateways, external APIs, badges, charts, and other remote services
- require contributor affiliation disclosure and links to official documentation and source repositories
- require stable examples, environment-based credentials, and reproducible compatibility evidence
- keep provider documentation limited to independently verifiable compatibility facts
- document trust-boundary requirements for externally hosted images and CI approval behavior

## Motivation

Recent provider and external-chart proposals exposed inconsistent review expectations. This policy keeps LightAgent provider-neutral, prevents unverified commercial or security claims from becoming project documentation, and gives contributors a clear path to submit verifiable integrations.

## Validation

- `git diff --check`: passed
- documentation-only change; no runtime behavior changed
