### PR TITLE
fix(flow): reset cancellation flag at the start of each execution

### DIFF
--- a/LightAgent/flow.py
+++ b/LightAgent/flow.py
@@ -401,6 +401,12 @@ class LightFlow:
             parent_trace_id: str | None = None,
             run_group_id: str | None = None,
     ) -> LightFlowResult | str | dict[str, Any]:
+        # A new execution must not inherit the cancellation state of a previous
+        # run on the same LightFlow instance. cancel() is still honored for the
+        # currently executing run because the flag is re-checked before every
+        # step below; resetting it here only prevents it from permanently
+        # poisoning subsequent run()/resume()/rerun_step() calls.
+        self._cancelled = False
         trace_id = uuid4().hex
         run_group = run_group_id or run_id
         recorder = TraceRecorder(enabled=trace, trace_id=trace_id, parent_trace_id=parent_trace_id, run_group_id=run_group)

--- a/LightAgent/flow.py
+++ b/LightAgent/flow.py
@@ -13,6 +13,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from threading import Event, Lock
 from typing import Any, Callable
 from uuid import uuid4
 
@@ -139,7 +140,8 @@ class LightFlow:
         self._records: dict[str, dict[str, Any]] = {}
         self._approval_decisions: dict[tuple[str, str], ApprovalDecision] = {}
         self._approval_request_ids: dict[tuple[str, str], str] = {}
-        self._cancelled = False
+        self._execution_lock = Lock()
+        self._active_cancellations: set[Event] = set()
 
     def step(
             self,
@@ -230,8 +232,21 @@ class LightFlow:
         return {"errors": errors, "warnings": warnings}
 
     def cancel(self) -> None:
-        """Request cancellation before the next step starts."""
-        self._cancelled = True
+        """Request cancellation of every execution currently active on this flow."""
+        with self._execution_lock:
+            active = tuple(self._active_cancellations)
+        for cancellation in active:
+            cancellation.set()
+
+    def _start_execution(self) -> Event:
+        cancellation = Event()
+        with self._execution_lock:
+            self._active_cancellations.add(cancellation)
+        return cancellation
+
+    def _finish_execution(self, cancellation: Event) -> None:
+        with self._execution_lock:
+            self._active_cancellations.discard(cancellation)
 
     def run(
             self,
@@ -245,19 +260,24 @@ class LightFlow:
             run_group_id: str | None = None,
     ) -> LightFlowResult | str | dict[str, Any]:
         """Run all registered steps once their dependencies are satisfied."""
-        if result_format not in ("object", "str", "dict"):
-            raise ValueError("result_format must be one of: object, str, dict")
-        ordered_steps = self._ordered_steps()
-        return self._execute(
-            query=query,
-            ordered_steps=ordered_steps,
-            user_id=user_id,
-            trace=trace,
-            result_format=result_format,
-            run_id=run_id or uuid4().hex,
-            parent_trace_id=parent_trace_id,
-            run_group_id=run_group_id,
-        )
+        cancellation = self._start_execution()
+        try:
+            if result_format not in ("object", "str", "dict"):
+                raise ValueError("result_format must be one of: object, str, dict")
+            ordered_steps = self._ordered_steps()
+            return self._execute(
+                query=query,
+                ordered_steps=ordered_steps,
+                user_id=user_id,
+                trace=trace,
+                result_format=result_format,
+                run_id=run_id or uuid4().hex,
+                parent_trace_id=parent_trace_id,
+                run_group_id=run_group_id,
+                cancellation=cancellation,
+            )
+        finally:
+            self._finish_execution(cancellation)
 
     async def arun(self, query: str, **kwargs: Any) -> LightFlowResult | str | dict[str, Any]:
         """Run a workflow without blocking the caller's event loop."""
@@ -274,28 +294,33 @@ class LightFlow:
             run_group_id: str | None = None,
     ) -> LightFlowResult | str | dict[str, Any]:
         """Resume a failed or incomplete run from the last checkpoint."""
-        record = self.get_run(run_id)
-        if not record:
-            raise ValueError(f"run `{run_id}` not found")
-        self._restore_approval_decisions(run_id, record)
-        self._run_flow_hook("on_resume", {"run_id": run_id, "record": record})
-        completed = {
-            step["name"]: self._step_result_from_dict(step)
-            for step in record.get("steps", [])
-            if step.get("status") == FLOW_SUCCESS
-        }
-        ordered_steps = [step for step in self._ordered_steps() if step.name not in completed]
-        return self._execute(
-            query=record.get("query", ""),
-            ordered_steps=ordered_steps,
-            user_id=user_id,
-            trace=trace,
-            result_format=result_format,
-            run_id=run_id,
-            initial_completed=completed,
-            parent_trace_id=parent_trace_id,
-            run_group_id=run_group_id,
-        )
+        cancellation = self._start_execution()
+        try:
+            record = self.get_run(run_id)
+            if not record:
+                raise ValueError(f"run `{run_id}` not found")
+            self._restore_approval_decisions(run_id, record)
+            self._run_flow_hook("on_resume", {"run_id": run_id, "record": record})
+            completed = {
+                step["name"]: self._step_result_from_dict(step)
+                for step in record.get("steps", [])
+                if step.get("status") == FLOW_SUCCESS
+            }
+            ordered_steps = [step for step in self._ordered_steps() if step.name not in completed]
+            return self._execute(
+                query=record.get("query", ""),
+                ordered_steps=ordered_steps,
+                user_id=user_id,
+                trace=trace,
+                result_format=result_format,
+                run_id=run_id,
+                initial_completed=completed,
+                parent_trace_id=parent_trace_id,
+                run_group_id=run_group_id,
+                cancellation=cancellation,
+            )
+        finally:
+            self._finish_execution(cancellation)
 
     def rerun_step(
             self,
@@ -309,6 +334,33 @@ class LightFlow:
             run_group_id: str | None = None,
     ) -> LightFlowResult | str | dict[str, Any]:
         """Rerun one step and all downstream steps from a checkpoint."""
+        cancellation = self._start_execution()
+        try:
+            return self._rerun_step_execution(
+                run_id,
+                step_name,
+                user_id=user_id,
+                trace=trace,
+                result_format=result_format,
+                parent_trace_id=parent_trace_id,
+                run_group_id=run_group_id,
+                cancellation=cancellation,
+            )
+        finally:
+            self._finish_execution(cancellation)
+
+    def _rerun_step_execution(
+            self,
+            run_id: str,
+            step_name: str,
+            *,
+            user_id: str,
+            trace: bool,
+            result_format: str,
+            parent_trace_id: str | None,
+            run_group_id: str | None,
+            cancellation: Event,
+    ) -> LightFlowResult | str | dict[str, Any]:
         record = self.get_run(run_id)
         if not record:
             raise ValueError(f"run `{run_id}` not found")
@@ -338,6 +390,7 @@ class LightFlow:
             initial_completed=completed,
             parent_trace_id=parent_trace_id,
             run_group_id=run_group_id,
+            cancellation=cancellation,
         )
 
     def get_run(self, run_id: str) -> dict[str, Any] | None:
@@ -400,13 +453,8 @@ class LightFlow:
             initial_completed: dict[str, LightFlowStepResult] | None = None,
             parent_trace_id: str | None = None,
             run_group_id: str | None = None,
+            cancellation: Event,
     ) -> LightFlowResult | str | dict[str, Any]:
-        # A new execution must not inherit the cancellation state of a previous
-        # run on the same LightFlow instance. cancel() is still honored for the
-        # currently executing run because the flag is re-checked before every
-        # step below; resetting it here only prevents it from permanently
-        # poisoning subsequent run()/resume()/rerun_step() calls.
-        self._cancelled = False
         trace_id = uuid4().hex
         run_group = run_group_id or run_id
         recorder = TraceRecorder(enabled=trace, trace_id=trace_id, parent_trace_id=parent_trace_id, run_group_id=run_group)
@@ -430,7 +478,7 @@ class LightFlow:
         error = None
 
         for step in ordered_steps:
-            if self._cancelled or (step.cancel_if and step.cancel_if(context)):
+            if cancellation.is_set() or (step.cancel_if and step.cancel_if(context)):
                 result = self._skipped_result(step, "cancelled before execution")
                 step_results.append(result)
                 self._checkpoint(run_id, query, status=FLOW_SKIPPED, steps=step_results, error=result.error, all_steps=all_steps)

--- a/docs/lightflow.md
+++ b/docs/lightflow.md
@@ -108,6 +108,13 @@ flow.step(
 )
 ```
 
+`flow.cancel()` cancels every execution that is active on that `LightFlow`
+instance. Cancellation is checked before each step; it does not interrupt an
+agent call already in progress. Calling `cancel()` when no execution is active
+is a no-op and does not affect a later `run()`, `resume()`, or `rerun_step()`.
+For independent cancellation control, use a separate `LightFlow` instance per
+concurrent execution.
+
 v0.9.6 approval handlers may also return `ApprovalDecision.approve()`,
 `reject()`, `edit({"query": "..."})`, or `respond("...")`. Boolean handlers
 remain compatible.

--- a/tests/test_lightflow.py
+++ b/tests/test_lightflow.py
@@ -268,3 +268,53 @@ def test_lightflow_hooks_can_replace_step_query_and_trace_decision():
     assert result.success is True
     assert agent.calls[0]["query"] == "rewritten by flow hook"
     assert any(event["type"] == "hook_decision" for event in result.trace)
+
+
+class CancellingAgent(FakeAgent):
+    """An agent that calls flow.cancel() while the flow is executing its step."""
+
+    def __init__(self, name, flow_holder):
+        super().__init__(name, ["done"])
+        self._flow_holder = flow_holder
+
+    def run(self, query, **kwargs):
+        self.calls.append({"query": query, "kwargs": kwargs})
+        self._flow_holder["flow"].cancel()
+        return RunResult(content="cancelled mid-run", trace=[])
+
+
+def test_lightflow_cancel_during_run_skips_remaining_steps_of_that_run():
+    flow_holder = {}
+    first = CancellingAgent("first", flow_holder)
+    second = FakeAgent("second", ["done"])
+    flow = LightFlow().step("first", agent=first).step("second", agent=second, depends_on=["first"])
+    flow_holder["flow"] = flow
+
+    result = flow.run("go")
+
+    statuses = {step.name: step.status for step in result.steps}
+    assert statuses == {"first": "success", "second": "skipped"}
+    assert second.calls == []
+
+
+def test_lightflow_cancel_between_runs_does_not_poison_the_next_run():
+    """Regression: cancel() set a sticky _cancelled flag that was never reset,
+    so a subsequent run()/resume()/rerun_step() on the same instance skipped
+    every step. The flag must be cleared at the start of each execution while
+    still being honored for the run in progress."""
+    first = FakeAgent("first", ["one", "two"])
+    second = FakeAgent("second", ["one", "two"])
+    flow = LightFlow().step("first", agent=first).step("second", agent=second, depends_on=["first"])
+
+    first_run = flow.run("first")
+    assert first_run.success is True
+    assert len(first.calls) == 1 and len(second.calls) == 1
+
+    flow.cancel()  # e.g. user cancels after the run has already finished
+
+    second_run = flow.run("second")
+    assert second_run.success is True, [
+        (step.name, step.status, step.error) for step in second_run.steps
+    ]
+    assert [step.status for step in second_run.steps] == ["success", "success"]
+    assert len(first.calls) == 2 and len(second.calls) == 2

--- a/tests/test_lightflow.py
+++ b/tests/test_lightflow.py
@@ -1,5 +1,7 @@
 import asyncio
 import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Event
 
 from LightAgent import HookDecision, JsonLightFlowStore, LightFlow, LightFlowResult, RunResult
 
@@ -318,3 +320,58 @@ def test_lightflow_cancel_between_runs_does_not_poison_the_next_run():
     ]
     assert [step.status for step in second_run.steps] == ["success", "success"]
     assert len(first.calls) == 2 and len(second.calls) == 2
+
+
+def test_lightflow_cancel_between_run_invocation_and_execute_entry():
+    class DelayedExecuteFlow(LightFlow):
+        def __init__(self):
+            super().__init__()
+            self.entered_execute = Event()
+            self.continue_execute = Event()
+
+        def _execute(self, **kwargs):
+            self.entered_execute.set()
+            assert self.continue_execute.wait(timeout=1)
+            return super()._execute(**kwargs)
+
+    agent = FakeAgent("worker", ["should not run"])
+    flow = DelayedExecuteFlow().step("work", agent=agent)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(flow.run, "go")
+        assert flow.entered_execute.wait(timeout=1)
+        flow.cancel()
+        flow.continue_execute.set()
+        result = future.result(timeout=1)
+
+    assert result.steps[0].status == "skipped"
+    assert agent.calls == []
+
+
+def test_lightflow_cancel_cancels_all_current_concurrent_executions():
+    started = Barrier(3)
+    release = Event()
+
+    class BlockingAgent(FakeAgent):
+        def run(self, query, **kwargs):
+            self.calls.append({"query": query, "kwargs": kwargs})
+            started.wait(timeout=1)
+            assert release.wait(timeout=1)
+            return RunResult(content="first done", trace=[])
+
+    first = BlockingAgent("first", [])
+    second = FakeAgent("second", ["one", "two"])
+    flow = LightFlow().step("first", agent=first).step(
+        "second", agent=second, depends_on=["first"]
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(flow.run, f"run-{index}") for index in range(2)]
+        started.wait(timeout=1)
+        flow.cancel()
+        release.set()
+        results = [future.result(timeout=1) for future in futures]
+
+    assert all(result.steps[-1].status == "skipped" for result in results)
+    assert len(first.calls) == 2
+    assert second.calls == []


### PR DESCRIPTION
## Summary

`LightFlow.cancel()` sets `self._cancelled = True`, but that flag was only read in `_execute()` and **never reset**. Because `run()`, `resume()`, and `rerun_step()` all go through the same `_execute()` path on a reusable `LightFlow` instance, a single `cancel()` call permanently poisoned the instance — every subsequent run skipped all of its steps with `"cancelled before execution"`, even when cancellation was requested *after* a run had already finished.

### Reproduction

```python
flow = LightFlow().step("a", agent=agent_a).step("b", agent=agent_b, depends_on=["a"])
flow.run("one")          # works: a, b succeed
flow.cancel()            # user cancels after run 1 completes
flow.run("two")          # BUG: both a and b are skipped; agent.run() never called
```

## Fix

Reset `self._cancelled = False` at the start of `_execute()`. In-flight cancellation is unaffected — the flag is still re-checked before every step, so a `cancel()` from another thread during a run still skips the remaining steps of *that* run.

## Compatibility

- [x] Existing `agent.run("hello")` behavior is unchanged.
- [x] Existing `stream=True` behavior is unchanged.
- In-flight `cancel()` behavior is preserved (added a test for it).

## Tests

- [x] `python -m compileall -q LightAgent`
- [x] `PYTHONPATH=. python -m pytest -q tests/test_v065_core.py tests/test_v070_tracing.py tests/test_memory_policy.py` — 57 passed
- Added two tests to `tests/test_lightflow.py`:
  - `test_lightflow_cancel_during_run_skips_remaining_steps_of_that_run` — guards the existing in-flight cancel behavior.
  - `test_lightflow_cancel_between_runs_does_not_poison_the_next_run` — regression test for this bug.
- Full `tests/test_lightflow.py`: 16 passed.