### PR TITLE
fix(flow): treat agent exceptions as failed steps so retry/fallback engage

### DIFF
--- a/LightAgent/flow.py
+++ b/LightAgent/flow.py
@@ -691,7 +691,7 @@ class LightFlow:
                 raw_result, timed_out = None, False
                 content = (
                     f"[LA-FLOW-AGENT-ERROR] step `{step.name}` agent raised "
-                    f"{type(exc).__name__}: {exc}"
+                    f"{type(exc).__name__}"
                 )
                 error, step_trace = content, []
             else:
@@ -732,7 +732,7 @@ class LightFlow:
                 fallback_result, timed_out = None, False
                 content = (
                     f"[LA-FLOW-AGENT-ERROR] fallback for step `{step.name}` agent raised "
-                    f"{type(exc).__name__}: {exc}"
+                    f"{type(exc).__name__}"
                 )
                 error, step_trace = content, []
             else:

--- a/LightAgent/flow.py
+++ b/LightAgent/flow.py
@@ -677,19 +677,28 @@ class LightFlow:
         started = time.perf_counter()
         last_result: LightFlowStepResult | None = None
         for attempt in range(1, step.max_retry + 1):
-            raw_result, timed_out = self._call_agent(
-                step.agent,
-                step,
-                query,
-                user_id=user_id,
-                trace=trace,
-                parent_trace_id=parent_trace_id,
-                run_group_id=run_group_id,
-            )
-            content, error, step_trace = self._normalize_agent_result(raw_result)
-            if timed_out:
-                error = f"step `{step.name}` timed out after {step.timeout} seconds"
-                content = f"[LA-FLOW-TIMEOUT] {error}"
+            try:
+                raw_result, timed_out = self._call_agent(
+                    step.agent,
+                    step,
+                    query,
+                    user_id=user_id,
+                    trace=trace,
+                    parent_trace_id=parent_trace_id,
+                    run_group_id=run_group_id,
+                )
+            except Exception as exc:  # agent.run raised - count as a failed attempt
+                raw_result, timed_out = None, False
+                content = (
+                    f"[LA-FLOW-AGENT-ERROR] step `{step.name}` agent raised "
+                    f"{type(exc).__name__}: {exc}"
+                )
+                error, step_trace = content, []
+            else:
+                content, error, step_trace = self._normalize_agent_result(raw_result)
+                if timed_out:
+                    error = f"step `{step.name}` timed out after {step.timeout} seconds"
+                    content = f"[LA-FLOW-TIMEOUT] {error}"
             ended = time.perf_counter()
             last_result = LightFlowStepResult(
                 name=step.name,
@@ -709,19 +718,28 @@ class LightFlow:
                 return last_result
 
         if last_result and last_result.error and step.fallback_agent is not None:
-            fallback_result, timed_out = self._call_agent(
-                step.fallback_agent,
-                step,
-                query,
-                user_id=user_id,
-                trace=trace,
-                parent_trace_id=parent_trace_id,
-                run_group_id=run_group_id,
-            )
-            content, error, step_trace = self._normalize_agent_result(fallback_result)
-            if timed_out:
-                error = f"fallback for step `{step.name}` timed out after {step.timeout} seconds"
-                content = f"[LA-FLOW-TIMEOUT] {error}"
+            try:
+                fallback_result, timed_out = self._call_agent(
+                    step.fallback_agent,
+                    step,
+                    query,
+                    user_id=user_id,
+                    trace=trace,
+                    parent_trace_id=parent_trace_id,
+                    run_group_id=run_group_id,
+                )
+            except Exception as exc:  # fallback agent raised - surface as a failed step
+                fallback_result, timed_out = None, False
+                content = (
+                    f"[LA-FLOW-AGENT-ERROR] fallback for step `{step.name}` agent raised "
+                    f"{type(exc).__name__}: {exc}"
+                )
+                error, step_trace = content, []
+            else:
+                content, error, step_trace = self._normalize_agent_result(fallback_result)
+                if timed_out:
+                    error = f"fallback for step `{step.name}` timed out after {step.timeout} seconds"
+                    content = f"[LA-FLOW-TIMEOUT] {error}"
             ended = time.perf_counter()
             return LightFlowStepResult(
                 name=step.name,

--- a/tests/test_lightflow.py
+++ b/tests/test_lightflow.py
@@ -268,3 +268,79 @@ def test_lightflow_hooks_can_replace_step_query_and_trace_decision():
     assert result.success is True
     assert agent.calls[0]["query"] == "rewritten by flow hook"
     assert any(event["type"] == "hook_decision" for event in result.trace)
+
+
+class RaisingAgent:
+    """An agent whose run() raises; simulates real LLM agents that raise on
+    API/network failures rather than returning a RunResult with an error."""
+
+    def __init__(self, name, failures, success="recovered"):
+        self.name = name
+        self._failures = failures
+        self._success = success
+        self.calls = []
+
+    def run(self, query, **kwargs):
+        self.calls.append({"query": query})
+        if self._failures > 0:
+            self._failures -= 1
+            raise RuntimeError("transient API error")
+        return self._success
+
+
+def test_lightflow_retries_when_agent_raises():
+    """Regression: a raised exception previously propagated out of run() on the
+    first attempt, so max_retry never engaged for agents that raise (the common
+    case for API/network errors). It must be treated as a failed attempt."""
+    flaky = RaisingAgent("flaky", failures=2, success="recovered")
+    flow = LightFlow().step("flaky", agent=flaky, max_retry=3)
+
+    result = flow.run("try it")
+
+    assert result.success is True
+    assert result.content == "recovered"
+    assert len(flaky.calls) == 3
+    assert result.steps[0].attempts == 3
+
+
+def test_lightflow_fallback_runs_when_agent_always_raises():
+    class AlwaysRaises:
+        name = "always"
+
+        def run(self, query, **kwargs):
+            raise RuntimeError("permanent failure")
+
+    fallback = FakeAgent("fallback", ["fallback done"])
+    flow = LightFlow().step("work", agent=AlwaysRaises(), max_retry=2, fallback_agent=fallback)
+
+    result = flow.run("go")
+
+    assert result.success is True
+    assert result.content == "fallback done"
+    assert result.steps[0].used_fallback is True
+    assert len(fallback.calls) == 1
+
+
+def test_lightflow_marks_step_failed_when_agent_always_raises_without_fallback():
+    class AlwaysRaises:
+        name = "always"
+
+        def run(self, query, **kwargs):
+            raise RuntimeError("permanent failure")
+
+    downstream = FakeAgent("downstream", ["should not run"])
+    flow = (
+        LightFlow()
+        .step("failing", agent=AlwaysRaises(), max_retry=2)
+        .step("downstream", agent=downstream, depends_on=["failing"])
+    )
+
+    result = flow.run("go")
+
+    assert result.success is False
+    assert "RuntimeError" in result.error
+    assert result.steps[0].status == "failed"
+    assert result.steps[0].attempts == 2
+    assert result.steps[1].status == "skipped"
+    assert downstream.calls == []
+

--- a/tests/test_lightflow.py
+++ b/tests/test_lightflow.py
@@ -344,3 +344,18 @@ def test_lightflow_marks_step_failed_when_agent_always_raises_without_fallback()
     assert result.steps[1].status == "skipped"
     assert downstream.calls == []
 
+
+def test_lightflow_does_not_expose_agent_exception_details():
+    class SecretRaisingAgent:
+        name = "secret"
+
+        def run(self, query, **kwargs):
+            raise RuntimeError("Authorization: Bearer secret-token")
+
+    result = LightFlow().step("secret", agent=SecretRaisingAgent()).run("go")
+
+    assert result.success is False
+    assert "RuntimeError" in result.error
+    assert "secret-token" not in result.error
+    assert "Authorization" not in result.error
+


### PR DESCRIPTION
## Summary

- `_run_step` called `_call_agent` without catching exceptions. Real agents typically **raise** on API/network/rate-limit failures (rather than returning a `RunResult` with `error` set), and `_call_agent` re-raises those — directly when no timeout is set, or via `future.result()` when one is. The exception therefore escaped the retry loop on the first attempt:
  - `max_retry` never retried a raising agent (the workflow crashed on attempt 1 instead of trying again),
  - `fallback_agent` was never consulted for a raising agent,
  - with no fallback, `flow.run()` raised instead of marking the step `failed` and skipping its dependents.
- Fix: wrap both the primary and fallback agent calls so a raised exception is normalized into a failed step result using the existing `[LA-FLOW-...]` error convention. The retry loop and fallback path then engage exactly as they do for errors returned in a `RunResult`, and the flow fails gracefully with downstream steps skipped.

### Reproduction (before this patch)

```python
class Flaky:
    def __init__(self): self.calls = 0
    def run(self, query, **kw):
        self.calls += 1
        if self.calls < 3:
            raise RuntimeError("transient API error")
        return "recovered"

flow = LightFlow().step("flaky", agent=Flaky(), max_retry=3)
flow.run("go")   # raised RuntimeError after 1 attempt; never retried
```

## Compatibility

- [x] Existing `agent.run("hello")` behavior is unchanged for agents that return normally.
- [x] Existing `stream=True` behavior is unchanged.
- Behavior change is strictly a fix: agents that raise no longer crash the orchestration; they are retried / fall back / mark the step failed, consistent with how `RunResult(error=...)` failures are already handled. `KeyboardInterrupt`/`SystemExit` (not subclasses of `Exception`) still propagate.

## Tests

- [x] `python -m compileall -q LightAgent`
- [x] `PYTHONPATH=. python -m pytest -q tests/test_lightflow.py` — 17 passed
- Added three regression tests:
  - `test_lightflow_retries_when_agent_raises` — a transiently-raising agent is retried and succeeds.
  - `test_lightflow_fallback_runs_when_agent_always_raises` — a persistently-raising agent falls back.
  - `test_lightflow_marks_step_failed_when_agent_always_raises_without_fallback` — the step is `failed`, the dependent step is `skipped`, and `run()` returns a failed result instead of raising.

## Notes

No API changes. The pre-existing retry/fallback tests only covered errors delivered via `RunResult(error=...)`; this covers the raised-exception path, which is the common failure mode for real LLM integrations.
