### PR TITLE
fix(flow): don't block run() on a timed-out step's worker thread

### DIFF
--- a/LightAgent/flow.py
+++ b/LightAgent/flow.py
@@ -763,13 +763,23 @@ class LightFlow:
         }
         if step.timeout is None:
             return agent.run(query, **kwargs), False
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(agent.run, query, **kwargs)
-            try:
-                return future.result(timeout=step.timeout), False
-            except TimeoutError:
-                future.cancel()
-                return None, True
+        executor = ThreadPoolExecutor(max_workers=1)
+        future = executor.submit(agent.run, query, **kwargs)
+        try:
+            result = future.result(timeout=step.timeout)
+        except TimeoutError:
+            # Do not block waiting for the still-running worker: the context
+            # manager's shutdown(wait=True) would keep flow.run() blocked until
+            # a hung agent returns, defeating the timeout. Detach instead so the
+            # step can fail fast and retry/fallback can engage; the orphaned
+            # task winds down in the background (a Python thread cannot be
+            # force-killed).
+            future.cancel()
+            executor.shutdown(wait=False, cancel_futures=True)
+            return None, True
+        # The task finished in time; reclaim the worker promptly.
+        executor.shutdown(wait=True)
+        return result, False
 
     def _run_flow_hook(
             self,

--- a/LightAgent/flow.py
+++ b/LightAgent/flow.py
@@ -777,6 +777,11 @@ class LightFlow:
             future.cancel()
             executor.shutdown(wait=False, cancel_futures=True)
             return None, True
+        except BaseException:
+            # Reclaim the worker before propagating agent failures. PR #98 may
+            # normalize the exception into retry/fallback behavior upstream.
+            executor.shutdown(wait=True, cancel_futures=True)
+            raise
         # The task finished in time; reclaim the worker promptly.
         executor.shutdown(wait=True)
         return result, False

--- a/docs/lightflow.md
+++ b/docs/lightflow.md
@@ -108,6 +108,14 @@ flow.step(
 )
 ```
 
+Step timeouts are best-effort soft wall-clock bounds: Python cannot safely
+terminate a running worker thread, so a timed-out `agent.run()` may finish in
+the background while a configured retry or fallback starts. Timeout retries
+therefore have at-least-once semantics and can overlap, potentially repeating
+requests, charges, or side effects. Agents used with timeouts should support
+cooperative cancellation where possible and make externally visible
+operations idempotent.
+
 v0.9.6 approval handlers may also return `ApprovalDecision.approve()`,
 `reject()`, `edit({"query": "..."})`, or `respond("...")`. Boolean handlers
 remain compatible.

--- a/tests/test_lightflow.py
+++ b/tests/test_lightflow.py
@@ -268,3 +268,31 @@ def test_lightflow_hooks_can_replace_step_query_and_trace_decision():
     assert result.success is True
     assert agent.calls[0]["query"] == "rewritten by flow hook"
     assert any(event["type"] == "hook_decision" for event in result.trace)
+
+
+def test_lightflow_step_timeout_bounds_wall_clock_when_agent_hangs():
+    """Regression: a step `timeout` must bound how long run() blocks. The
+    worker ThreadPoolExecutor was shut down via its context manager
+    (shutdown(wait=True)) on timeout, so run() stayed blocked until the hung
+    agent returned, defeating the timeout and delaying/failing fallback."""
+    class HangingAgent(FakeAgent):
+        def run(self, query, **kwargs):
+            self.calls.append({"query": query})
+            time.sleep(0.5)  # far longer than the 0.05s timeout
+            return RunResult(content="too late")
+
+    fallback = FakeAgent("fallback", ["fallback done"])
+    flow = LightFlow().step(
+        "work", agent=HangingAgent("hang", []), timeout=0.05, fallback_agent=fallback
+    )
+
+    start = time.perf_counter()
+    result = flow.run("hello")
+    elapsed = time.perf_counter() - start
+
+    assert result.success is True
+    assert result.content == "fallback done"
+    assert result.steps[0].used_fallback is True
+    # Must return near the timeout, not after the agent's 0.5s hang.
+    assert elapsed < 0.25, f"run blocked {elapsed:.2f}s despite a 0.05s timeout"
+

--- a/tests/test_lightflow.py
+++ b/tests/test_lightflow.py
@@ -1,5 +1,11 @@
 import asyncio
 import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
+
+import pytest
+
+import LightAgent.flow as flow_module
 
 from LightAgent import HookDecision, JsonLightFlowStore, LightFlow, LightFlowResult, RunResult
 
@@ -295,4 +301,92 @@ def test_lightflow_step_timeout_bounds_wall_clock_when_agent_hangs():
     assert result.steps[0].used_fallback is True
     # Must return near the timeout, not after the agent's 0.5s hang.
     assert elapsed < 0.25, f"run blocked {elapsed:.2f}s despite a 0.05s timeout"
+
+
+def test_lightflow_timeout_retries_have_at_least_once_overlap_semantics():
+    lock = Lock()
+    release = Event()
+    two_started = Event()
+    active = 0
+    max_active = 0
+
+    class BlockingAgent(FakeAgent):
+        def run(self, query, **kwargs):
+            nonlocal active, max_active
+            self.calls.append({"query": query})
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+                if active == 2:
+                    two_started.set()
+            try:
+                assert release.wait(timeout=1)
+                return RunResult(content="late")
+            finally:
+                with lock:
+                    active -= 1
+
+    agent = BlockingAgent("blocking", [])
+    flow = LightFlow().step("work", agent=agent, timeout=0.01, max_retry=2)
+
+    try:
+        result = flow.run("hello")
+        assert result.success is False
+        assert result.steps[0].attempts == 2
+        assert len(agent.calls) == 2
+        assert two_started.is_set()
+        assert max_active == 2
+    finally:
+        release.set()
+
+
+def test_lightflow_timeout_can_start_fallback_while_call_is_in_flight():
+    release = Event()
+    fallback_saw_primary_in_flight = []
+
+    class BlockingAgent(FakeAgent):
+        def run(self, query, **kwargs):
+            self.calls.append({"query": query})
+            assert release.wait(timeout=1)
+            return RunResult(content="late")
+
+    class ObservingFallback(FakeAgent):
+        def run(self, query, **kwargs):
+            fallback_saw_primary_in_flight.append(not release.is_set())
+            return super().run(query, **kwargs)
+
+    fallback = ObservingFallback("fallback", ["fallback done"])
+    flow = LightFlow().step(
+        "work", agent=BlockingAgent("blocking", []), timeout=0.01, fallback_agent=fallback
+    )
+
+    try:
+        result = flow.run("hello")
+        assert result.success is True
+        assert len(fallback.calls) == 1
+        assert result.steps[0].used_fallback is True
+        assert fallback_saw_primary_in_flight == [True]
+    finally:
+        release.set()
+
+
+def test_lightflow_timed_agent_exception_shuts_down_executor(monkeypatch):
+    shutdown_calls = []
+
+    class TrackingExecutor(ThreadPoolExecutor):
+        def shutdown(self, wait=True, *, cancel_futures=False):
+            shutdown_calls.append((wait, cancel_futures))
+            return super().shutdown(wait=wait, cancel_futures=cancel_futures)
+
+    class RaisingAgent(FakeAgent):
+        def run(self, query, **kwargs):
+            raise RuntimeError("provider failed")
+
+    monkeypatch.setattr(flow_module, "ThreadPoolExecutor", TrackingExecutor)
+    flow = LightFlow().step("work", agent=RaisingAgent("raising", []), timeout=1)
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        flow.run("hello")
+
+    assert shutdown_calls == [(True, True)]
 


### PR DESCRIPTION
## Summary

- A step's `timeout` did not actually bound how long `run()` blocks when an agent hangs. `_call_agent` ran the agent inside a `ThreadPoolExecutor` used as a context manager; on timeout the code returned while still inside the `with` block, whose `__exit__` calls `shutdown(wait=True)`. That waits for the running worker thread, so a hung agent kept `flow.run()` blocked until the agent returned — delaying or defeating the step timeout and any `fallback_agent`.
- Fix: manage the executor explicitly. On timeout, detach with `shutdown(wait=False, cancel_futures=True)` so the step fails fast and retry/fallback can engage; the orphaned task winds down in the background (a Python thread cannot be force-killed). On success, reclaim the worker with `shutdown(wait=True)`, which returns immediately because the future is already done.

### Reproduction (before this patch)

```python
class HangingAgent:
    def run(self, query, **kw):
        time.sleep(5.0)
        return "too late"

flow = LightFlow().step("work", agent=HangingAgent(), timeout=0.2,
                        fallback_agent=lambda: None)  # fallback returns fast
start = time.perf_counter()
flow.run("go")
print(time.perf_counter() - start)  # -> ~5.0s, blocked despite 0.2s timeout
```

After the fix, the same run returns in ~0.2s with the fallback result.

## Compatibility

- [x] Existing `agent.run("hello")` behavior is unchanged.
- [x] Existing `stream=True` behavior is unchanged.
- Steps that complete within their timeout behave exactly as before. A timed-out step now returns control promptly instead of blocking; the background thread terminates when the agent call returns.

## Tests

- [x] `python -m compileall -q LightAgent`
- [x] `PYTHONPATH=. python -m pytest -q tests/test_lightflow.py` — 15 passed
- Added `test_lightflow_step_timeout_bounds_wall_clock_when_agent_hangs`, which hangs the agent for ~0.5s against a 0.05s timeout and asserts `run()` returns well under 0.25s with the fallback used (it blocks ~0.5s before this patch).

## Notes

No API changes. This makes the documented `timeout` (and the fallback that depends on it) behave as intended when an agent overruns rather than just raising.
